### PR TITLE
feat: add GHAR multi-agent TDD issue resolution workflow

### DIFF
--- a/.github/workflows/core-opencode-run.yml
+++ b/.github/workflows/core-opencode-run.yml
@@ -8,11 +8,11 @@ on:
         required: true
         type: string
       prompt:
-        description: 'Runtime prompt content; appended to prompt-file when both are provided'
+        description: 'The prompt content to use for the run (mutually exclusive with prompt-file)'
         required: false
         type: string
       prompt-file:
-        description: 'Path to the base prompt file; runtime prompt content is appended when provided'
+        description: 'Path to the prompt file (e.g., .github/prompts/security.prompt.md) (mutually exclusive with prompt)'
         required: false
         type: string
       timeout-minutes:
@@ -110,57 +110,25 @@ jobs:
             fi
           fi
 
-      - name: Build prompt
-        id: prompt
-        env:
-          PROMPT_FILE: ${{ inputs.prompt-file }}
-          RUNTIME_PROMPT: ${{ inputs.prompt }}
+      - name: Run OpenCode ${{ inputs.run-name }}
         run: |
-          if [ -z "$PROMPT_FILE" ] && [ -z "$RUNTIME_PROMPT" ]; then
-            if [ -n "${{ inputs.command }}" ]; then
-              exit 0
+          if [ -n "${{ inputs.command }}" ]; then
+            if [ -n "${{ inputs.prompt }}" ]; then
+              echo "${{ inputs.prompt }}" | env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --command "${{ inputs.command }}" --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
+            elif [ -n "${{ inputs.prompt-file }}" ]; then
+              PROMPT=$(cat ${{ inputs.prompt-file }})
+              echo "$PROMPT" | env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --command "${{ inputs.command }}" --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
+            else
+              env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --command "${{ inputs.command }}" --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
             fi
+          elif [ -n "${{ inputs.prompt }}" ]; then
+            echo "${{ inputs.prompt }}" | env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
+          elif [ -n "${{ inputs.prompt-file }}" ]; then
+            PROMPT=$(cat ${{ inputs.prompt-file }})
+            echo "$PROMPT" | env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
+          else
             echo "Error: At least one of 'command', 'prompt', or 'prompt-file' must be provided" >&2
             exit 1
-          fi
-
-          : > "$RUNNER_TEMP/opencode-prompt.txt"
-          if [ -n "$PROMPT_FILE" ]; then
-            if [ ! -f "$PROMPT_FILE" ]; then
-              echo "Error: Prompt file not found: $PROMPT_FILE" >&2
-              exit 1
-            fi
-            cat "$PROMPT_FILE" >> "$RUNNER_TEMP/opencode-prompt.txt"
-          fi
-          if [ -n "$PROMPT_FILE" ] && [ -n "$RUNTIME_PROMPT" ]; then
-            printf '\n\n## Runtime Input\n\n' >> "$RUNNER_TEMP/opencode-prompt.txt"
-          fi
-          if [ -n "$RUNTIME_PROMPT" ]; then
-            printf '%s\n' "$RUNTIME_PROMPT" >> "$RUNNER_TEMP/opencode-prompt.txt"
-          fi
-          echo "has-prompt=true" >> "$GITHUB_OUTPUT"
-
-      - name: Run OpenCode ${{ inputs.run-name }}
-        env:
-          OPENCODE_COMMAND: ${{ inputs.command }}
-          OPENCODE_MODEL: ${{ inputs.model }}
-          OPENCODE_AGENT: ${{ inputs.agent }}
-          RESULTS_FILE: ${{ inputs.run-name }}-results.txt
-        run: |
-          if [ "${{ steps.prompt.outputs.has-prompt }}" = "true" ]; then
-            if [ -n "$OPENCODE_COMMAND" ]; then
-              env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" \
-                opencode run --command "$OPENCODE_COMMAND" --model "$OPENCODE_MODEL" --agent "$OPENCODE_AGENT" \
-                < "$RUNNER_TEMP/opencode-prompt.txt" > "$RESULTS_FILE"
-            else
-              env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" \
-                opencode run --model "$OPENCODE_MODEL" --agent "$OPENCODE_AGENT" \
-                < "$RUNNER_TEMP/opencode-prompt.txt" > "$RESULTS_FILE"
-            fi
-          else
-            env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" \
-              opencode run --command "$OPENCODE_COMMAND" --model "$OPENCODE_MODEL" --agent "$OPENCODE_AGENT" \
-              > "$RESULTS_FILE"
           fi
 
       - name: Process results for output

--- a/.github/workflows/core-opencode-run.yml
+++ b/.github/workflows/core-opencode-run.yml
@@ -8,11 +8,11 @@ on:
         required: true
         type: string
       prompt:
-        description: 'The prompt content to use for the run (mutually exclusive with prompt-file)'
+        description: 'Runtime prompt content; appended to prompt-file when both are provided'
         required: false
         type: string
       prompt-file:
-        description: 'Path to the prompt file (e.g., .github/prompts/security.prompt.md) (mutually exclusive with prompt)'
+        description: 'Path to the base prompt file; runtime prompt content is appended when provided'
         required: false
         type: string
       timeout-minutes:
@@ -110,25 +110,57 @@ jobs:
             fi
           fi
 
-      - name: Run OpenCode ${{ inputs.run-name }}
+      - name: Build prompt
+        id: prompt
+        env:
+          PROMPT_FILE: ${{ inputs.prompt-file }}
+          RUNTIME_PROMPT: ${{ inputs.prompt }}
         run: |
-          if [ -n "${{ inputs.command }}" ]; then
-            if [ -n "${{ inputs.prompt }}" ]; then
-              echo "${{ inputs.prompt }}" | env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --command "${{ inputs.command }}" --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
-            elif [ -n "${{ inputs.prompt-file }}" ]; then
-              PROMPT=$(cat ${{ inputs.prompt-file }})
-              echo "$PROMPT" | env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --command "${{ inputs.command }}" --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
-            else
-              env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --command "${{ inputs.command }}" --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
+          if [ -z "$PROMPT_FILE" ] && [ -z "$RUNTIME_PROMPT" ]; then
+            if [ -n "${{ inputs.command }}" ]; then
+              exit 0
             fi
-          elif [ -n "${{ inputs.prompt }}" ]; then
-            echo "${{ inputs.prompt }}" | env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
-          elif [ -n "${{ inputs.prompt-file }}" ]; then
-            PROMPT=$(cat ${{ inputs.prompt-file }})
-            echo "$PROMPT" | env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" opencode run --model "${{ inputs.model }}" --agent "${{ inputs.agent }}" > ${{ inputs.run-name }}-results.txt
-          else
             echo "Error: At least one of 'command', 'prompt', or 'prompt-file' must be provided" >&2
             exit 1
+          fi
+
+          : > "$RUNNER_TEMP/opencode-prompt.txt"
+          if [ -n "$PROMPT_FILE" ]; then
+            if [ ! -f "$PROMPT_FILE" ]; then
+              echo "Error: Prompt file not found: $PROMPT_FILE" >&2
+              exit 1
+            fi
+            cat "$PROMPT_FILE" >> "$RUNNER_TEMP/opencode-prompt.txt"
+          fi
+          if [ -n "$PROMPT_FILE" ] && [ -n "$RUNTIME_PROMPT" ]; then
+            printf '\n\n## Runtime Input\n\n' >> "$RUNNER_TEMP/opencode-prompt.txt"
+          fi
+          if [ -n "$RUNTIME_PROMPT" ]; then
+            printf '%s\n' "$RUNTIME_PROMPT" >> "$RUNNER_TEMP/opencode-prompt.txt"
+          fi
+          echo "has-prompt=true" >> "$GITHUB_OUTPUT"
+
+      - name: Run OpenCode ${{ inputs.run-name }}
+        env:
+          OPENCODE_COMMAND: ${{ inputs.command }}
+          OPENCODE_MODEL: ${{ inputs.model }}
+          OPENCODE_AGENT: ${{ inputs.agent }}
+          RESULTS_FILE: ${{ inputs.run-name }}-results.txt
+        run: |
+          if [ "${{ steps.prompt.outputs.has-prompt }}" = "true" ]; then
+            if [ -n "$OPENCODE_COMMAND" ]; then
+              env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" \
+                opencode run --command "$OPENCODE_COMMAND" --model "$OPENCODE_MODEL" --agent "$OPENCODE_AGENT" \
+                < "$RUNNER_TEMP/opencode-prompt.txt" > "$RESULTS_FILE"
+            else
+              env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" \
+                opencode run --model "$OPENCODE_MODEL" --agent "$OPENCODE_AGENT" \
+                < "$RUNNER_TEMP/opencode-prompt.txt" > "$RESULTS_FILE"
+            fi
+          else
+            env -i PATH="$HOME/.opencode/bin:$PATH" HOME="$HOME" GH_TOKEN="$GH_TOKEN" \
+              opencode run --command "$OPENCODE_COMMAND" --model "$OPENCODE_MODEL" --agent "$OPENCODE_AGENT" \
+              > "$RESULTS_FILE"
           fi
 
       - name: Process results for output

--- a/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
+++ b/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
@@ -1,0 +1,224 @@
+name: GHAR Multi-Agent TDD Issue Resolution
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "GitHub issue number to resolve"
+        required: true
+        type: string
+
+concurrency:
+  group: ghar-multi-agent-issue-${{ inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  setup-branch:
+    name: "0. Setup Shared Branch"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
+    outputs:
+      branch_name: ${{ steps.branch.outputs.branch_name }}
+    steps:
+      - name: Validate issue number
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          case "$ISSUE_NUMBER" in
+            ''|*[!0-9]*) echo "issue_number must contain digits only" >&2; exit 1 ;;
+          esac
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}" --silent
+
+      - name: Checkout default branch
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create or reuse shared branch
+        id: branch
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Reusing existing branch $BRANCH"
+          else
+            git push origin "HEAD:refs/heads/$BRANCH"
+          fi
+          echo "branch_name=$BRANCH" >> "$GITHUB_OUTPUT"
+
+  planner-requirements:
+    name: "1A. Planner: Requirements"
+    needs: setup-branch
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: planner-requirements
+      prompt-file: .opencode/commands/ghar-planner-requirements.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 30
+    permissions: {contents: read, issues: write, pull-requests: write}
+    secrets: inherit
+
+  planner-architecture:
+    name: "1B. Planner: Architecture"
+    needs: setup-branch
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: planner-architecture
+      prompt-file: .opencode/commands/ghar-planner-architecture.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 30
+    permissions: {contents: read, issues: write, pull-requests: write}
+    secrets: inherit
+
+  planner-risks:
+    name: "1C. Planner: Risks"
+    needs: setup-branch
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: planner-risks
+      prompt-file: .opencode/commands/ghar-planner-risks.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 30
+    permissions: {contents: read, issues: write, pull-requests: write}
+    secrets: inherit
+
+  spec-synthesizer:
+    name: "2. Spec Synthesizer"
+    needs: [planner-requirements, planner-architecture, planner-risks]
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: spec-synthesizer
+      prompt-file: .opencode/commands/ghar-spec-synthesizer.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 30
+    permissions: {contents: read, issues: write, pull-requests: write}
+    secrets: inherit
+
+  tdd-reviewer:
+    name: "3. TDD Reviewer"
+    needs: spec-synthesizer
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: tdd-reviewer
+      prompt-file: .opencode/commands/ghar-tdd-reviewer.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 30
+    permissions: {contents: read, issues: write, pull-requests: write}
+    secrets: inherit
+
+  spec-finalizer:
+    name: "4. Spec Finalizer"
+    needs: tdd-reviewer
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: spec-finalizer
+      prompt-file: .opencode/commands/ghar-spec-finalizer.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 30
+    permissions: {contents: read, issues: write, pull-requests: write}
+    secrets: inherit
+
+  test-agent:
+    name: "5. Test Agent"
+    needs: spec-finalizer
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: test-agent
+      prompt-file: .opencode/commands/ghar-test-agent.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 45
+    permissions: {contents: write, issues: write, pull-requests: write}
+    secrets: inherit
+
+  implementer:
+    name: "6. Implementer"
+    needs: test-agent
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: implementer
+      prompt-file: .opencode/commands/ghar-implementer.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 60
+    permissions: {contents: write, issues: write, pull-requests: write}
+    secrets: inherit
+
+  reviewer:
+    name: "7A. Reviewer"
+    needs: implementer
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: reviewer
+      prompt-file: .opencode/commands/ghar-reviewer.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 30
+    permissions: {contents: read, issues: write, pull-requests: write}
+    secrets: inherit
+
+  redteam:
+    name: "7B. Red Team"
+    needs: implementer
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: redteam
+      prompt-file: .opencode/commands/ghar-redteam.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 45
+    permissions: {contents: write, issues: write, pull-requests: write}
+    secrets: inherit
+
+  ci-agent:
+    name: "8. CI Evidence Agent"
+    needs: [reviewer, redteam]
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: ci-agent
+      prompt-file: .opencode/commands/ghar-ci-agent.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 60
+    permissions: {actions: read, checks: read, contents: read, issues: read, pull-requests: read}
+    secrets: inherit
+
+  failure-classifier:
+    name: "9. Failure Classifier"
+    needs: ci-agent
+    if: ${{ always() && needs.ci-agent.result != 'cancelled' }}
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: failure-classifier
+      prompt-file: .opencode/commands/ghar-failure-classifier.md
+      prompt: |
+        Issue number: ${{ inputs.issue_number }}
+        CI agent job result: ${{ needs.ci-agent.result }}
+        CI agent report:
+        ${{ needs.ci-agent.outputs.results }}
+      timeout-minutes: 30
+    permissions: {actions: read, checks: read, contents: read, issues: write, pull-requests: write}
+    secrets: inherit
+
+  fixer-integrator:
+    name: "10. Fixer / Integrator"
+    needs: failure-classifier
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: fixer-integrator
+      prompt-file: .opencode/commands/ghar-fixer-integrator.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 60
+    permissions: {actions: read, checks: read, contents: write, issues: write, pull-requests: write}
+    secrets: inherit
+
+  pr-finalizer:
+    name: "11. PR Finalizer"
+    needs: fixer-integrator
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: pr-finalizer
+      prompt-file: .opencode/commands/ghar-pr-finalizer.md
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 30
+    permissions: {actions: read, checks: read, contents: read, issues: write, pull-requests: write}
+    secrets: inherit

--- a/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
+++ b/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
@@ -56,7 +56,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: planner-requirements
-      prompt-file: .opencode/commands/ghar-planner-requirements.md
+      command: ghar-planner-requirements
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
     permissions: {contents: read, issues: write, pull-requests: write}
@@ -68,7 +68,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: planner-architecture
-      prompt-file: .opencode/commands/ghar-planner-architecture.md
+      command: ghar-planner-architecture
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
     permissions: {contents: read, issues: write, pull-requests: write}
@@ -80,7 +80,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: planner-risks
-      prompt-file: .opencode/commands/ghar-planner-risks.md
+      command: ghar-planner-risks
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
     permissions: {contents: read, issues: write, pull-requests: write}
@@ -92,7 +92,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: spec-synthesizer
-      prompt-file: .opencode/commands/ghar-spec-synthesizer.md
+      command: ghar-spec-synthesizer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
     permissions: {contents: read, issues: write, pull-requests: write}
@@ -104,7 +104,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: tdd-reviewer
-      prompt-file: .opencode/commands/ghar-tdd-reviewer.md
+      command: ghar-tdd-reviewer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
     permissions: {contents: read, issues: write, pull-requests: write}
@@ -116,7 +116,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: spec-finalizer
-      prompt-file: .opencode/commands/ghar-spec-finalizer.md
+      command: ghar-spec-finalizer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
     permissions: {contents: read, issues: write, pull-requests: write}
@@ -128,7 +128,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: test-agent
-      prompt-file: .opencode/commands/ghar-test-agent.md
+      command: ghar-test-agent
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
     permissions: {contents: write, issues: write, pull-requests: write}
@@ -140,7 +140,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: implementer
-      prompt-file: .opencode/commands/ghar-implementer.md
+      command: ghar-implementer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
     permissions: {contents: write, issues: write, pull-requests: write}
@@ -152,7 +152,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: reviewer
-      prompt-file: .opencode/commands/ghar-reviewer.md
+      command: ghar-reviewer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
     permissions: {contents: read, issues: write, pull-requests: write}
@@ -164,7 +164,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: redteam
-      prompt-file: .opencode/commands/ghar-redteam.md
+      command: ghar-redteam
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
     permissions: {contents: write, issues: write, pull-requests: write}
@@ -176,7 +176,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: ci-agent
-      prompt-file: .opencode/commands/ghar-ci-agent.md
+      command: ghar-ci-agent
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
     permissions: {actions: read, checks: read, contents: read, issues: read, pull-requests: read}
@@ -189,7 +189,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: failure-classifier
-      prompt-file: .opencode/commands/ghar-failure-classifier.md
+      command: ghar-failure-classifier
       prompt: |
         Issue number: ${{ inputs.issue_number }}
         CI agent job result: ${{ needs.ci-agent.result }}
@@ -205,7 +205,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: fixer-integrator
-      prompt-file: .opencode/commands/ghar-fixer-integrator.md
+      command: ghar-fixer-integrator
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
     permissions: {actions: read, checks: read, contents: write, issues: write, pull-requests: write}
@@ -217,7 +217,7 @@ jobs:
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: pr-finalizer
-      prompt-file: .opencode/commands/ghar-pr-finalizer.md
+      command: ghar-pr-finalizer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
     permissions: {actions: read, checks: read, contents: read, issues: write, pull-requests: write}

--- a/.opencode/commands/ghar-ci-agent.md
+++ b/.opencode/commands/ghar-ci-agent.md
@@ -1,0 +1,35 @@
+---
+description: Run repository-native CI checks and return an evidence report
+---
+
+# CI Evidence Agent
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Fetch and check out the latest shared branch read-only. Do not publish an issue artifact. Determine repository-native CI commands from workflow files, build metadata, and contributor documentation. Run the narrow relevant suite plus the feasible standard lint/type/test/build checks. Continue collecting independent failures instead of stopping after the first command.
+
+Also inspect GitHub check runs for the shared branch or its pull request when available. Return a concise report in your final output containing:
+
+1. Branch and tested commit SHA
+2. Every exact command run, exit status, and short relevant error excerpt
+3. GitHub check status observed, without claiming success unless verified
+4. Distinction between test failures and environment/tooling limitations
+5. Links or identifiers for available Actions/check runs
+
+## Boundaries
+
+Do not modify files, create commits/comments, install untrusted project-global tooling, or fabricate green status. Test commands may generate ignored build artifacts; remove them before finishing and leave the worktree clean.

--- a/.opencode/commands/ghar-ci-agent.md
+++ b/.opencode/commands/ghar-ci-agent.md
@@ -1,13 +1,18 @@
 ---
 description: Run repository-native CI checks and return an evidence report
+argument-hint: <issue-number>
 ---
 
 # CI Evidence Agent
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-failure-classifier.md
+++ b/.opencode/commands/ghar-failure-classifier.md
@@ -1,13 +1,18 @@
 ---
 description: Classify CI failures and route evidence-based repairs
+argument-hint: <issue-number-and-ci-report>
 ---
 
 # Failure Classifier
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+The first line of `$ARGUMENTS` identifies the GitHub issue number; the remaining text may contain the CI-agent report. Extract the numeric issue number into `ISSUE_NUMBER` and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-failure-classifier.md
+++ b/.opencode/commands/ghar-failure-classifier.md
@@ -1,0 +1,36 @@
+---
+description: Classify CI failures and route evidence-based repairs
+---
+
+# Failure Classifier
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+The runtime input includes the issue number and CI-agent report. Fetch the latest shared branch read-only. Read `spec-approved`, `tests-created`, and `implementation-done`, plus available Actions/check logs. Classify every observed failure using evidence.
+
+Publish `<!-- failure-classification -->` with:
+
+1. `# Failure Classification`
+2. Tested commit and CI/check status
+3. Failure table: exact command/check, symptom, category, evidence, root cause, owner, and priority
+4. Categories covering implementation bug, adversarial regression, test defect, flaky test, environment/tooling, pre-existing failure, or spec ambiguity
+5. Recommended repair order and verification commands
+6. Explicit “no failures observed” statement when evidence is green
+
+## Boundaries
+
+Do not modify files/tests/spec, commit, ignore environmental or flaky failures, or infer a root cause without log evidence. Quote only short relevant error excerpts.

--- a/.opencode/commands/ghar-fixer-integrator.md
+++ b/.opencode/commands/ghar-fixer-integrator.md
@@ -1,13 +1,18 @@
 ---
 description: Repair and integrate reviewer, red-team, and CI findings
+argument-hint: <issue-number>
 ---
 
 # Fixer / Integrator
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-fixer-integrator.md
+++ b/.opencode/commands/ghar-fixer-integrator.md
@@ -1,0 +1,38 @@
+---
+description: Repair and integrate reviewer, red-team, and CI findings
+---
+
+# Fixer / Integrator
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Require `spec-approved`, `review-findings`, `redteam-findings`, and `failure-classification`. Fetch and check out the latest shared branch. Prioritize blockers, repair production defects, address credible adversarial failures, and restore repository-native checks.
+
+Production code and documentation may be changed. A small test correction is allowed only when the classifier/review evidence proves the test is wrong; explain it explicitly. Never remove, skip, or weaken a valid test. Run narrow verification and the feasible full suite, commit integrated changes if any, and push only `HEAD:refs/heads/$BRANCH`.
+
+Publish `<!-- fixer-summary -->` with:
+
+1. `# Fixer / Integrator Summary`
+2. Finding-by-finding disposition
+3. Commit SHA(s) and files changed (or state no changes were needed)
+4. Exact verification commands and outcomes
+5. Any justified minor test correction
+6. Remaining risks/blockers, without hiding failures
+
+## Boundaries
+
+Do not change acceptance criteria, approved architecture, or scope; do not redesign, weaken evidence, or push elsewhere. Prefer surgical fixes.

--- a/.opencode/commands/ghar-implementer.md
+++ b/.opencode/commands/ghar-implementer.md
@@ -1,0 +1,37 @@
+---
+description: Implement production behavior without changing tests
+---
+
+# Implementer
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Require `spec-approved` and `tests-created`. Fetch and check out the shared branch at its latest remote head. Confirm the test commit is present and reproduce its meaningful failures. Implement the smallest production change that satisfies the approved spec and tests.
+
+Modify production files only. Do not edit tests, fixtures, snapshots, or the spec. Run narrow tests and broader relevant checks. Before committing, compare changed paths against the test commit and verify this commit adds no test-file changes. Commit production changes and push only `HEAD:refs/heads/$BRANCH`.
+
+Publish `<!-- implementation-done -->` with:
+
+1. `# Implementation Complete`
+2. Commit SHA and files changed
+3. Behavior implemented and preserved
+4. Exact test/check commands and outcomes
+5. Remaining known issues or a spec/test challenge
+
+## Boundaries
+
+No test cheating, unrelated refactors, architecture expansion, hidden failures, or pushes to another branch. If a test appears wrong, do not change it; document the challenge in this artifact for the Fixer/human.

--- a/.opencode/commands/ghar-implementer.md
+++ b/.opencode/commands/ghar-implementer.md
@@ -1,13 +1,18 @@
 ---
 description: Implement production behavior without changing tests
+argument-hint: <issue-number>
 ---
 
 # Implementer
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-planner-architecture.md
+++ b/.opencode/commands/ghar-planner-architecture.md
@@ -1,13 +1,18 @@
 ---
 description: Design the smallest repo-native architecture for an issue
+argument-hint: <issue-number>
 ---
 
 # Architecture Planner
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-planner-architecture.md
+++ b/.opencode/commands/ghar-planner-architecture.md
@@ -1,0 +1,37 @@
+---
+description: Design the smallest repo-native architecture for an issue
+---
+
+# Architecture Planner
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Read only the issue body/non-agent discussion and inspect the shared branch. Make an independent architecture-first pass. Do not read any GHAR artifact comments or implementation diff.
+
+Publish `<!-- plan-architecture -->` with:
+
+1. `# Architecture Plan`
+2. Relevant existing code paths and repository conventions
+3. Affected files/modules and why
+4. Smallest coherent technical approach
+5. Explicit interface or data-flow changes
+6. Test locations and fixture needs (without writing tests)
+7. Dependencies, migrations, compatibility, and concise tradeoffs
+
+## Boundaries
+
+Do not modify files, commit, write tests, finalize product scope, or change acceptance criteria. Prefer existing patterns and avoid broad refactors or speculative abstractions.

--- a/.opencode/commands/ghar-planner-requirements.md
+++ b/.opencode/commands/ghar-planner-requirements.md
@@ -1,13 +1,18 @@
 ---
 description: Plan issue requirements as observable, testable behavior
+argument-hint: <issue-number>
 ---
 
 # Requirements Planner
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-planner-requirements.md
+++ b/.opencode/commands/ghar-planner-requirements.md
@@ -1,0 +1,37 @@
+---
+description: Plan issue requirements as observable, testable behavior
+---
+
+# Requirements Planner
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Read the issue body, non-agent discussion, and relevant code on the shared branch. Make an independent requirements-first pass. Do not read comments whose first line is a GHAR artifact marker, including other planner output.
+
+Publish `<!-- plan-requirements -->` with:
+
+1. `# Requirements Plan`
+2. User stories and business intent
+3. Atomic must-have acceptance criteria in observable language
+4. Nice-to-have behavior clearly separated from must-haves
+5. Existing behavior that must remain unchanged
+6. Non-goals and assumptions
+7. Open requirement questions that do not block a minimal safe implementation
+
+## Boundaries
+
+Do not modify files, create commits, design broad architecture, infer new scope, or read implementation diffs. Flag ambiguity rather than guessing. Write for the Test Agent.

--- a/.opencode/commands/ghar-planner-risks.md
+++ b/.opencode/commands/ghar-planner-risks.md
@@ -1,0 +1,37 @@
+---
+description: Identify issue risks, regressions, and concrete edge cases
+---
+
+# Risk Planner
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Read only the issue body/non-agent discussion and inspect the shared branch. Make an independent failure-first pass. Do not read any GHAR artifact comments or implementation diff.
+
+Publish `<!-- plan-risks -->` with:
+
+1. `# Risk Plan`
+2. Risk register with severity, likelihood, and evidence
+3. Boundary, invalid-input, concurrency, compatibility, security, and data-integrity cases where relevant
+4. Regression and flaky-test concerns
+5. Concrete test scenario mapped to each realistic risk
+6. Rollback or compatibility notes
+7. Dangerous assumptions and non-blocking unknowns
+
+## Boundaries
+
+Do not modify files, commit, set final scope, solve the issue, or propose a large rewrite. Prioritize reproducible risks and avoid speculative blockers.

--- a/.opencode/commands/ghar-planner-risks.md
+++ b/.opencode/commands/ghar-planner-risks.md
@@ -1,13 +1,18 @@
 ---
 description: Identify issue risks, regressions, and concrete edge cases
+argument-hint: <issue-number>
 ---
 
 # Risk Planner
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-pr-finalizer.md
+++ b/.opencode/commands/ghar-pr-finalizer.md
@@ -1,0 +1,39 @@
+---
+description: Create or update the human-ready pull request and final artifact
+---
+
+# PR Finalizer
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Require all artifacts: `spec-approved`, `tests-created`, `implementation-done`, `review-findings`, `redteam-findings`, `failure-classification`, and `fixer-summary`. Fetch the latest shared branch read-only. Compare it with the repository default branch, inspect commit order, changed files, and available checks.
+
+Create exactly one pull request from `$BRANCH` to the repository default branch, or update the existing open/closed-unmerged pull request for that head. Never create a duplicate. The PR body must link `Closes #$ISSUE_NUMBER` and summarize scope, implementation, TDD commit ordering, tests/checks, review/red-team dispositions, and unresolved risks. Do not enable auto-merge or merge the PR.
+
+Publish `<!-- pr-final -->` with:
+
+1. `# Final PR Readiness Report`
+2. PR number and URL
+3. Final commit and changed-file summary
+4. Artifact-chain completeness
+5. Exact verified tests/check status
+6. Resolved and unresolved risk summary
+7. Human review checklist and explicit merge decision request
+
+## Boundaries
+
+Do not modify files/code/tests/spec, create commits, claim unverified CI success, hide risks, approve, or merge. The human reviewer is the first required interaction and owns the final decision.

--- a/.opencode/commands/ghar-pr-finalizer.md
+++ b/.opencode/commands/ghar-pr-finalizer.md
@@ -1,13 +1,18 @@
 ---
 description: Create or update the human-ready pull request and final artifact
+argument-hint: <issue-number>
 ---
 
 # PR Finalizer
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-redteam.md
+++ b/.opencode/commands/ghar-redteam.md
@@ -1,13 +1,18 @@
 ---
 description: Attack the implementation and commit only justified adversarial tests
+argument-hint: <issue-number>
 ---
 
 # Red Team
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-redteam.md
+++ b/.opencode/commands/ghar-redteam.md
@@ -1,0 +1,37 @@
+---
+description: Attack the implementation and commit only justified adversarial tests
+---
+
+# Red Team
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Require `spec-approved`, `tests-created`, and `implementation-done`. Fetch and check out the latest shared branch. Preserve independence: do not read `review-findings`. Attack realistic assumptions using boundaries, invalid inputs, compatibility, concurrency, security, and data integrity as applicable.
+
+You may modify only tests, fixtures, snapshots, and test-only helpers. Add a minimal adversarial test only when it demonstrates a credible uncovered scenario. Run relevant tests. If files changed, commit and push only `HEAD:refs/heads/$BRANCH`; otherwise do not create an empty commit.
+
+Publish `<!-- redteam-findings -->` with:
+
+1. `# Red-Team Findings`
+2. Attack scenarios attempted and evidence
+3. Adversarial tests added, commit SHA, and exact commands (or state none)
+4. Failures found and severity
+5. Residual risk assessment
+
+## Boundaries
+
+Do not modify production code/spec, read reviewer output, duplicate existing coverage, or add unrealistic tests. Inspect changed paths before commit and revert anything outside test ownership.

--- a/.opencode/commands/ghar-reviewer.md
+++ b/.opencode/commands/ghar-reviewer.md
@@ -1,13 +1,18 @@
 ---
 description: Independently review implementation correctness and maintainability
+argument-hint: <issue-number>
 ---
 
 # Independent Reviewer
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-reviewer.md
+++ b/.opencode/commands/ghar-reviewer.md
@@ -1,0 +1,37 @@
+---
+description: Independently review implementation correctness and maintainability
+---
+
+# Independent Reviewer
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Fetch the latest shared branch without modifying it. Read the issue plus `spec-approved`, `tests-created`, and `implementation-done`; verify all markers exist. Review the commits and diff against the repository default branch. Preserve independence: do not read `redteam-findings` even if it already exists.
+
+Publish `<!-- review-findings -->` with:
+
+1. `# Independent Review Findings`
+2. Blocking findings ordered by severity, with file/line evidence
+3. Non-blocking correctness or maintainability findings
+4. Security/performance/compatibility observations when relevant
+5. Test adequacy and spec-compliance assessment
+6. Concrete suggested fixes
+7. Explicit approval statement if no blocker exists
+
+## Boundaries
+
+Do not modify files, commit, change tests/spec, or nitpick without impact. Do not rubber-stamp; make findings specific and actionable.

--- a/.opencode/commands/ghar-spec-finalizer.md
+++ b/.opencode/commands/ghar-spec-finalizer.md
@@ -1,13 +1,18 @@
 ---
 description: Finalize an autonomous TDD-ready implementation contract
+argument-hint: <issue-number>
 ---
 
 # Spec Finalizer
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-spec-finalizer.md
+++ b/.opencode/commands/ghar-spec-finalizer.md
@@ -1,0 +1,38 @@
+---
+description: Finalize an autonomous TDD-ready implementation contract
+---
+
+# Spec Finalizer
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Read the issue, codebase, `spec-final`, and `spec-tdd-review`. Verify both markers exist. Resolve every TDD objection by accepting it, rejecting it with evidence, or marking it explicitly out of scope without weakening issue requirements.
+
+Publish `<!-- spec-approved -->` with:
+
+1. `# Approved TDD-Ready Implementation Spec`
+2. Approved goal and non-goals
+3. Final numbered acceptance criteria
+4. Final technical decisions, interfaces, and affected areas
+5. Required failing-test checklist mapped to acceptance criteria
+6. Risk mitigations and preserved behavior
+7. Definition-of-done checklist
+8. TDD-objection disposition table
+
+## Boundaries
+
+Do not modify files, commit, create tests/code, expand scope, leave contradictions, or defer a required autonomous decision to a human. This artifact becomes immutable once implementation starts.

--- a/.opencode/commands/ghar-spec-synthesizer.md
+++ b/.opencode/commands/ghar-spec-synthesizer.md
@@ -1,0 +1,39 @@
+---
+description: Synthesize planner artifacts into one implementation specification
+---
+
+# Spec Synthesizer
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Read the issue, codebase, and exactly these artifact comments: `plan-requirements`, `plan-architecture`, and `plan-risks`. Verify all three markers exist before proceeding. Resolve conflicts explicitly and choose the smallest safe, repo-native decision.
+
+Publish `<!-- spec-final -->` with:
+
+1. `# Synthesized Implementation Spec`
+2. Goal, user-visible outcome, assumptions, and non-goals
+3. Numbered, testable acceptance criteria
+4. Technical decisions and interfaces
+5. Expected affected files/modules
+6. Risks and mitigations
+7. TDD plan mapping every must-have criterion to a test level
+8. Definition of done
+9. Conflict-resolution log and any residual risks
+
+## Boundaries
+
+Do not modify files or create commits. Do not widen scope, ignore planner conflicts, leave vague criteria, or write implementation code.

--- a/.opencode/commands/ghar-spec-synthesizer.md
+++ b/.opencode/commands/ghar-spec-synthesizer.md
@@ -1,13 +1,18 @@
 ---
 description: Synthesize planner artifacts into one implementation specification
+argument-hint: <issue-number>
 ---
 
 # Spec Synthesizer
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-tdd-reviewer.md
+++ b/.opencode/commands/ghar-tdd-reviewer.md
@@ -1,0 +1,37 @@
+---
+description: Challenge the synthesized spec for testability and coverage
+---
+
+# TDD Reviewer
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Read the issue, codebase, test framework, and only the `spec-final` planning artifact. Verify its marker exists. Attack the spec from a testability perspective.
+
+Publish `<!-- spec-tdd-review -->` with:
+
+1. `# TDD Spec Review`
+2. Criterion-to-test traceability table
+3. Required initial failing tests, separated into unit/integration/smoke levels
+4. Missing negative and regression cases
+5. Fixture, isolation, determinism, and failure-message expectations
+6. Explicit spec objections, each marked blocking or non-blocking
+7. A verdict: ready as written or requires finalizer corrections
+
+## Boundaries
+
+Do not modify files, commit, write repository tests, redesign architecture, or inspect future implementation artifacts. Every must-have criterion must be provable by a test or identified as untestable.

--- a/.opencode/commands/ghar-tdd-reviewer.md
+++ b/.opencode/commands/ghar-tdd-reviewer.md
@@ -1,13 +1,18 @@
 ---
 description: Challenge the synthesized spec for testability and coverage
+argument-hint: <issue-number>
 ---
 
 # TDD Reviewer
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-test-agent.md
+++ b/.opencode/commands/ghar-test-agent.md
@@ -1,13 +1,18 @@
 ---
 description: Create and commit failing tests from the approved spec
+argument-hint: <issue-number>
 ---
 
 # Test Agent
 
+**Input**: $ARGUMENTS
+
+---
+
 
 ## Runtime Contract
 
-The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
 
 ```bash
 BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"

--- a/.opencode/commands/ghar-test-agent.md
+++ b/.opencode/commands/ghar-test-agent.md
@@ -1,0 +1,38 @@
+---
+description: Create and commit failing tests from the approved spec
+---
+
+# Test Agent
+
+
+## Runtime Contract
+
+The runtime input contains the GitHub issue number. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Require the `spec-approved` artifact. Fetch and check out the shared branch with `git fetch origin "$BRANCH"` and `git checkout -B "$BRANCH" "origin/$BRANCH"`. Inspect existing tests, then encode the approved acceptance criteria as the smallest deterministic set of tests that fail for the intended missing behavior.
+
+Before editing, record the baseline changed-file list. Modify only test files, fixtures, snapshots, and test-only helpers. Run the narrow relevant tests and preserve evidence that the new tests fail for the expected reason—not due to syntax, environment, or unrelated failures. Commit with a TDD-focused message and push only `HEAD:refs/heads/$BRANCH`.
+
+Publish `<!-- tests-created -->` with:
+
+1. `# Tests Created`
+2. Commit SHA
+3. Test-only files changed
+4. Acceptance criteria and edge cases covered
+5. Exact commands run and expected initial failures
+6. Any untestable criterion or blocker
+
+## Boundaries
+
+Do not modify production code or the approved spec, weaken assertions, skip relevant failures, or add brittle tests. Before committing, inspect `git diff --name-only` and revert any file outside your allowed ownership.

--- a/Makefile.ghar
+++ b/Makefile.ghar
@@ -22,10 +22,25 @@ BASE_URL = https://raw.githubusercontent.com/$(SOURCE_REPO)/$(SOURCE_BRANCH)
 # Files to install (local_path:description)
 GHAR_FILES = \
 	.github/workflows/core-opencode-run.yml:OpenCode_runner \
+	.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml:Multi-agent_TDD_issue_resolution_workflow \
 	.github/workflows/ghar-daily-routine.yml:Daily_routine_workflow \
 	.github/workflows/ghar-issue-opened.yml:Auto_issue_investigation_workflow \
 	.github/workflows/ghar-issue-command-executor.yml:Issue_comment_command_executor \
 	.github/workflows/ghar-issue-commands-list.yml:Issue_commands_lister \
+	.opencode/commands/ghar-planner-requirements.md:Requirements_planner_command \
+	.opencode/commands/ghar-planner-architecture.md:Architecture_planner_command \
+	.opencode/commands/ghar-planner-risks.md:Risk_planner_command \
+	.opencode/commands/ghar-spec-synthesizer.md:Spec_synthesizer_command \
+	.opencode/commands/ghar-tdd-reviewer.md:TDD_reviewer_command \
+	.opencode/commands/ghar-spec-finalizer.md:Spec_finalizer_command \
+	.opencode/commands/ghar-test-agent.md:Test_agent_command \
+	.opencode/commands/ghar-implementer.md:Implementer_command \
+	.opencode/commands/ghar-reviewer.md:Independent_reviewer_command \
+	.opencode/commands/ghar-redteam.md:Red_team_command \
+	.opencode/commands/ghar-ci-agent.md:CI_evidence_agent_command \
+	.opencode/commands/ghar-failure-classifier.md:Failure_classifier_command \
+	.opencode/commands/ghar-fixer-integrator.md:Fixer_integrator_command \
+	.opencode/commands/ghar-pr-finalizer.md:PR_finalizer_command \
 	.opencode/commands/ghar-stale-check.md:Stale_check_command \
 	.opencode/commands/ghar-issue-investigate.md:Issue_investigation_command \
 	.opencode/commands/ghar-issue-fix.md:Issue_fix_command \


### PR DESCRIPTION
### Motivation

- Provide a reusable GHAR workflow to autonomously resolve medium-complexity issues using a single shared branch, idempotent issue-comment artifacts, TDD-first tests, independent review/red-team, CI classification, and a human PR merge decision.
- Reuse the existing `core-opencode-run.yml` runner while fixing its prompt handling so `prompt-file` can be combined with runtime `prompt` (issue context) rather than ignored. 
- Ensure installer consistency so the new workflow and command contracts can be deployed via the repo's `Makefile.ghar` in piped and dry-run modes.

### Description

- Add `.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml`, a `workflow_dispatch` workflow that validates an `issue_number`, creates/uses a non-destructive shared branch `agent/issue-<n>-implementation`, and executes the planned job graph for planning → spec → TDD → implement → review/red-team → CI → fixer → PR finalizer. 
- Update `.github/workflows/core-opencode-run.yml` to compose a prompt by concatenating a base `prompt-file` with a runtime `prompt` (issue number/context) and to feed that combined prompt reliably into `opencode run`. 
- Add role-specific command contract files under `.opencode/commands/` for planners, synthesizers, TDD reviewer, test agent, implementer, reviewer, red-team, CI agent, failure classifier, fixer, and PR finalizer, each specifying the artifact marker and precise branch/file ownership guardrails. 
- Update `Makefile.ghar` to register the new workflow and all command files so the installer works in normal, forced, dry-run, and piped modes, and preserve the requirement to check Makefile impact when adding files.

### Testing

- Ran `make -f Makefile.ghar validate` which reported success. 
- Performed a piped dry-install with `cat Makefile.ghar | make -f - install-dry` in a temporary directory and verified the new workflow and command files are included and installer directories are created. 
- Verified installer path consistency and that all workflow `prompt-file` references exist in `.opencode/commands`. 
- Ran `actionlint` against the modified workflows and found the new/modified workflows pass lint checks while a pre-existing, unrelated `actionlint` warning remains in an untouched workflow (`ghar-issue-command-executor.yml`). 
- Ran repository checks including `git diff --check` and other automated validations; all checks completed successfully aside from the noted unrelated warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2307a9c7188332815a43a79ac2c2d3)