### PR TITLE
chore: bump ghar version to 0.4.0

### DIFF
--- a/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
+++ b/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
@@ -98,9 +98,21 @@ jobs:
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
-  tdd-reviewer:
-    name: "3. TDD Reviewer"
+  spec-redteam:
+    name: "3. Spec Red Team"
     needs: spec-synthesizer
+    uses: ./.github/workflows/core-opencode-run.yml
+    with:
+      run-name: spec-redteam
+      command: ghar-spec-redteam
+      prompt: ${{ inputs.issue_number }}
+      timeout-minutes: 30
+    permissions: {contents: read, issues: write, pull-requests: write}
+    secrets: inherit
+
+  tdd-reviewer:
+    name: "4. TDD Reviewer"
+    needs: spec-redteam
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: tdd-reviewer
@@ -111,8 +123,8 @@ jobs:
     secrets: inherit
 
   spec-finalizer:
-    name: "4. Spec Finalizer"
-    needs: tdd-reviewer
+    name: "5. Spec Finalizer"
+    needs: [spec-redteam, tdd-reviewer]
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: spec-finalizer
@@ -123,7 +135,7 @@ jobs:
     secrets: inherit
 
   test-agent:
-    name: "5. Test Agent"
+    name: "6. Test Agent"
     needs: spec-finalizer
     uses: ./.github/workflows/core-opencode-run.yml
     with:
@@ -135,7 +147,7 @@ jobs:
     secrets: inherit
 
   implementer:
-    name: "6. Implementer"
+    name: "7. Implementer"
     needs: test-agent
     uses: ./.github/workflows/core-opencode-run.yml
     with:
@@ -147,7 +159,7 @@ jobs:
     secrets: inherit
 
   reviewer:
-    name: "7A. Reviewer"
+    name: "8A. Reviewer"
     needs: implementer
     uses: ./.github/workflows/core-opencode-run.yml
     with:
@@ -159,7 +171,7 @@ jobs:
     secrets: inherit
 
   redteam:
-    name: "7B. Red Team"
+    name: "8B. Red Team"
     needs: implementer
     uses: ./.github/workflows/core-opencode-run.yml
     with:
@@ -171,7 +183,7 @@ jobs:
     secrets: inherit
 
   ci-agent:
-    name: "8. CI Evidence Agent"
+    name: "9. CI Evidence Agent"
     needs: [reviewer, redteam]
     uses: ./.github/workflows/core-opencode-run.yml
     with:
@@ -183,7 +195,7 @@ jobs:
     secrets: inherit
 
   failure-classifier:
-    name: "9. Failure Classifier"
+    name: "10. Failure Classifier"
     needs: ci-agent
     if: ${{ always() && needs.ci-agent.result != 'cancelled' }}
     uses: ./.github/workflows/core-opencode-run.yml
@@ -200,7 +212,7 @@ jobs:
     secrets: inherit
 
   fixer-integrator:
-    name: "10. Fixer / Integrator"
+    name: "11. Fixer / Integrator"
     needs: failure-classifier
     uses: ./.github/workflows/core-opencode-run.yml
     with:
@@ -211,9 +223,59 @@ jobs:
     permissions: {actions: read, checks: read, contents: write, issues: write, pull-requests: write}
     secrets: inherit
 
-  pr-finalizer:
-    name: "11. PR Finalizer"
+  post-fix-ci-gate:
+    name: "12. Post-Fix CI Gate"
     needs: fixer-integrator
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ inputs.issue_number }}
+    steps:
+      - name: Wait for the latest branch checks to settle
+        run: |
+          set -euo pipefail
+          BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+          SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH}" --jq '.object.sha')"
+          echo "Watching ${BRANCH} at ${SHA}"
+
+          attempt=0
+          while [ "$attempt" -lt 60 ]; do
+            attempt=$((attempt + 1))
+
+            check_runs="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs?per_page=100")"
+            status_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/status")"
+
+            failed_runs="$(printf '%s' "$check_runs" | jq '[.check_runs[] | select(.status == "completed" and .conclusion != "success")] | length')"
+            pending_runs="$(printf '%s' "$check_runs" | jq '[.check_runs[] | select(.status != "completed")] | length')"
+            status_state="$(printf '%s' "$status_json" | jq -r '.state')"
+
+            if [ "$failed_runs" -gt 0 ]; then
+              echo "Latest CI checks failed for ${SHA}" >&2
+              printf '%s' "$check_runs" | jq -r '.check_runs[] | select(.status == "completed" and .conclusion != "success") | "- \(.name): \(.conclusion)\n  \(.details_url // "")"' >&2
+              exit 1
+            fi
+
+            if [ "$pending_runs" -eq 0 ] && [ "$status_state" != "pending" ]; then
+              echo "Latest CI checks have settled for ${SHA}"
+              printf '%s' "$status_json" | jq -r '.statuses[]? | select(.state != "success") | "- \(.context): \(.state)\n  \(.target_url // "")"' >&2
+              exit 0
+            fi
+
+            sleep 30
+          done
+
+          echo "Latest CI checks did not reach a terminal state for ${SHA}" >&2
+          printf '%s' "$check_runs" | jq -r '.check_runs[] | select(.status != "completed" or .conclusion != "success") | "- \(.name): \(.status) / \(.conclusion // "")\n  \(.details_url // "")"' >&2
+          printf '%s' "$status_json" | jq -r '.statuses[]? | select(.state != "success") | "- \(.context): \(.state)\n  \(.target_url // "")"' >&2
+          exit 1
+
+  pr-finalizer:
+    name: "13. PR Finalizer"
+    needs: [fixer-integrator, post-fix-ci-gate]
     uses: ./.github/workflows/core-opencode-run.yml
     with:
       run-name: pr-finalizer

--- a/.opencode/commands/ghar-ci-agent.md
+++ b/.opencode/commands/ghar-ci-agent.md
@@ -27,9 +27,11 @@ To publish an artifact, write the complete Markdown body to a temporary file. It
 
 Fetch and check out the latest shared branch read-only. Do not publish an issue artifact. Determine repository-native CI commands from workflow files, build metadata, and contributor documentation. Run the narrow relevant suite plus the feasible standard lint/type/test/build checks. Continue collecting independent failures instead of stopping after the first command.
 
+Do not treat CI as verified until the latest shared branch head has reached a terminal state. Poll GitHub check runs and status contexts for the current branch head until every required repository-native item is completed, or until you hit a clear timeout. Report terminal external status failures separately; do not imply success if anything is still pending at timeout.
+
 Before running checks, bootstrap the required toolchain for the current context. Discover what the repository expects, then install or enable only the missing tools needed for the selected commands in this job. Do not assume tools installed by another workflow step or another sub-workflow are present here. If a required tool is unavailable, report it as an environment limitation rather than skipping the check.
 
-Also inspect GitHub check runs for the shared branch or its pull request when available. Return a concise report in your final output containing:
+Also inspect GitHub check runs for the shared branch or its pull request when available, and re-check them until they stop moving. Return a concise report in your final output containing:
 
 1. Branch and tested commit SHA
 2. Every exact command run, exit status, and short relevant error excerpt

--- a/.opencode/commands/ghar-fixer-integrator.md
+++ b/.opencode/commands/ghar-fixer-integrator.md
@@ -27,7 +27,9 @@ To publish an artifact, write the complete Markdown body to a temporary file. It
 
 Require `spec-approved`, `review-findings`, `redteam-findings`, and `failure-classification`. Fetch and check out the latest shared branch. Prioritize blockers, repair production defects, address credible adversarial failures, and restore repository-native checks.
 
-Production code and documentation may be changed. A small test correction is allowed only when the classifier/review evidence proves the test is wrong; explain it explicitly. Never remove, skip, or weaken a valid test. Run narrow verification and the feasible full suite, commit integrated changes if any, and push only `HEAD:refs/heads/$BRANCH`.
+Own the repair loop end-to-end: after every push, re-check the latest branch head and wait for the newest CI cycle to settle. If checks are still pending, keep waiting rather than handing off early. If checks fail, classify the failure, repair it, and verify again before publishing the summary.
+
+Production code and documentation may be changed. A small test correction is allowed only when the classifier/review evidence proves the test is wrong; explain it explicitly. Never remove, skip, or weaken a valid test. Run narrow verification and the feasible full suite, commit integrated changes if any, and push only `HEAD:refs/heads/$BRANCH`. Do not consider the fix complete until the latest branch head has terminal CI evidence for the required repository-native checks.
 
 Before verification, bootstrap the tools needed for the checks you are about to run. Detect the repo’s test or validation expectations first, then install or enable only the missing tools required in this job’s context. Treat earlier sub-workflow environments as unrelated; a tool available to the test agent is not guaranteed to exist here. If a tool is missing and cannot be installed, record that limitation explicitly instead of replacing the check with a weaker one.
 

--- a/.opencode/commands/ghar-planner-architecture.md
+++ b/.opencode/commands/ghar-planner-architecture.md
@@ -36,6 +36,7 @@ Publish `<!-- plan-architecture -->` with:
 5. Explicit interface or data-flow changes
 6. Test locations and fixture needs (without writing tests)
 7. Dependencies, migrations, compatibility, and concise tradeoffs
+8. Minimum viable fix path and sibling-code cross-checks that may indicate the bug is systemic
 
 ## Boundaries
 

--- a/.opencode/commands/ghar-planner-requirements.md
+++ b/.opencode/commands/ghar-planner-requirements.md
@@ -36,6 +36,7 @@ Publish `<!-- plan-requirements -->` with:
 5. Existing behavior that must remain unchanged
 6. Non-goals and assumptions
 7. Open requirement questions that do not block a minimal safe implementation
+8. Exact observable success/failure signals for the must-have cases
 
 ## Boundaries
 

--- a/.opencode/commands/ghar-planner-risks.md
+++ b/.opencode/commands/ghar-planner-risks.md
@@ -36,6 +36,7 @@ Publish `<!-- plan-risks -->` with:
 5. Concrete test scenario mapped to each realistic risk
 6. Rollback or compatibility notes
 7. Dangerous assumptions and non-blocking unknowns
+8. Hidden overengineering or implementation-coupling risks in the proposed approach
 
 ## Boundaries
 

--- a/.opencode/commands/ghar-pr-finalizer.md
+++ b/.opencode/commands/ghar-pr-finalizer.md
@@ -27,6 +27,8 @@ To publish an artifact, write the complete Markdown body to a temporary file. It
 
 Require all artifacts: `spec-approved`, `tests-created`, `implementation-done`, `review-findings`, `redteam-findings`, `failure-classification`, and `fixer-summary`. Fetch the latest shared branch read-only. Compare it with the repository default branch, inspect commit order, changed files, and available checks.
 
+Treat any CI state older than the latest fixer push as stale. Do not finalize if the latest branch head has pending, failing, missing, or unobserved required repository-native checks. Require the post-fix CI gate to have observed the latest terminal CI state before considering the PR ready, and report any terminal external status failures separately.
+
 Create exactly one pull request from `$BRANCH` to the repository default branch, or update the existing open/closed-unmerged pull request for that head. Never create a duplicate. The PR body must link `Closes #$ISSUE_NUMBER` and summarize scope, implementation, TDD commit ordering, tests/checks, review/red-team dispositions, and unresolved risks. Do not enable auto-merge or merge the PR.
 
 Publish `<!-- pr-final -->` with:

--- a/.opencode/commands/ghar-redteam.md
+++ b/.opencode/commands/ghar-redteam.md
@@ -25,7 +25,7 @@ To publish an artifact, write the complete Markdown body to a temporary file. It
 
 ## Mission
 
-Require `spec-approved`, `tests-created`, and `implementation-done`. Fetch and check out the latest shared branch. Preserve independence: do not read `review-findings`. Attack realistic assumptions using boundaries, invalid inputs, compatibility, concurrency, security, and data integrity as applicable.
+Require `spec-approved`, `tests-created`, and `implementation-done`. Fetch and check out the latest shared branch. Preserve independence: do not read `review-findings`. Attack realistic assumptions using boundaries, invalid inputs, compatibility, concurrency, security, and data integrity as applicable. Also attack premature CI handoff and implementation-coupled tests that can be replaced by behavior-based checks.
 
 You may modify only tests, fixtures, snapshots, and test-only helpers. Add a minimal adversarial test only when it demonstrates a credible uncovered scenario. Run relevant tests. If files changed, commit and push only `HEAD:refs/heads/$BRANCH`; otherwise do not create an empty commit.
 

--- a/.opencode/commands/ghar-review.md
+++ b/.opencode/commands/ghar-review.md
@@ -21,6 +21,8 @@ Perform a thorough, senior-engineer-level code review:
 
 **Golden Rule**: Be constructive and actionable. Every issue should have a clear recommendation. Acknowledge good work too.
 
+Prefer the smallest correct change. Flag extra abstractions, wrappers, helper layers, or implementation-coupled tests when a simpler behavior-based alternative exists.
+
 ---
 
 ## Phase 1: FETCH - Get PR Context
@@ -208,6 +210,7 @@ For each file in the diff:
 - [ ] Is it over-engineered?
 - [ ] Is it under-engineered (missing necessary abstractions)?
 - [ ] Are there magic numbers/strings that should be constants?
+- [ ] Are tests asserting behavior instead of private implementation details when behavior is observable?
 
 ### 3.3 Categorize Issues
 

--- a/.opencode/commands/ghar-spec-finalizer.md
+++ b/.opencode/commands/ghar-spec-finalizer.md
@@ -25,7 +25,9 @@ To publish an artifact, write the complete Markdown body to a temporary file. It
 
 ## Mission
 
-Read the issue, codebase, `spec-final`, and `spec-tdd-review`. Verify both markers exist. Resolve every TDD objection by accepting it, rejecting it with evidence, or marking it explicitly out of scope without weakening issue requirements.
+Read the issue, codebase, `spec-final`, `spec-redteam`, and `spec-tdd-review`. Verify all markers exist. Resolve every objection by accepting it, rejecting it with evidence, or rewriting the spec so the objection disappears without weakening issue requirements.
+
+Reject any spec that still contains untestable must-have criteria, unresolved contradictions, implementation-coupled test language, or an unclear minimum viable fix. Keep the contract testable through observable behavior.
 
 Publish `<!-- spec-approved -->` with:
 
@@ -37,6 +39,7 @@ Publish `<!-- spec-approved -->` with:
 6. Risk mitigations and preserved behavior
 7. Definition-of-done checklist
 8. TDD-objection disposition table
+9. Red-team objection disposition table
 
 ## Boundaries
 

--- a/.opencode/commands/ghar-spec-redteam.md
+++ b/.opencode/commands/ghar-spec-redteam.md
@@ -1,0 +1,45 @@
+---
+description: Attack the synthesized plan before implementation and force falsification
+argument-hint: <issue-number>
+---
+
+# Spec Red Team
+
+**Input**: $ARGUMENTS
+
+---
+
+
+## Runtime Contract
+
+Extract the GitHub issue number from `$ARGUMENTS`. Set `ISSUE_NUMBER` to that numeric value and set:
+
+```bash
+BRANCH="agent/issue-${ISSUE_NUMBER}-implementation"
+```
+
+Use `gh api` with `GH_TOKEN` to read the issue and its comments. Never push to `main` or the repository default branch. Do not expose private reasoning; publish only the requested artifact.
+
+To publish an artifact, write the complete Markdown body to a temporary file. Its first line must be the exact marker shown below. Find comments with `gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100"`, selecting an exact first-line marker match. If one exists, update that comment with `gh api --method PATCH`; otherwise create it with `gh api --method POST`. If legacy duplicates exist, update the newest matching comment and delete the older matching duplicates. Do not create a second artifact comment.
+
+
+## Mission
+
+Read the issue, codebase, and exactly these artifact comments: `plan-requirements`, `plan-architecture`, `plan-risks`, and `spec-final`. Verify their markers exist before proceeding. Attack the synthesized spec from a falsification perspective.
+
+Find contradictions, untestable criteria, hidden scope expansion, implementation-coupled test ideas, missing negative cases, and any place where the spec permits overengineering or leaves the minimum viable fix unclear.
+
+Publish `<!-- spec-redteam -->` with:
+
+1. `# Spec Red-Team Review`
+2. Attack scenarios attempted and evidence
+3. Contradiction matrix: criterion, conflict, why it matters, recommended rewrite
+4. Must-have criteria lacking a runtime-observable test
+5. Missing negative, regression, and boundary cases
+6. Minimum-viable-fix check and overengineering risks
+7. Explicit objections, each marked blocking or non-blocking
+8. Verdict: ready for finalization or requires spec-finalizer corrections
+
+## Boundaries
+
+Do not modify files, commit, write tests, or finalize the spec. Prefer concrete falsification over style commentary.

--- a/.opencode/commands/ghar-spec-synthesizer.md
+++ b/.opencode/commands/ghar-spec-synthesizer.md
@@ -27,6 +27,8 @@ To publish an artifact, write the complete Markdown body to a temporary file. It
 
 Read the issue, codebase, and exactly these artifact comments: `plan-requirements`, `plan-architecture`, and `plan-risks`. Verify all three markers exist before proceeding. Resolve conflicts explicitly and choose the smallest safe, repo-native decision.
 
+Build a contradiction matrix before writing the spec. Where the planner artifacts disagree, say which criterion wins and why. Make every must-have criterion observable, testable, and tied to the smallest viable code change. If a criterion cannot be observed at runtime, rewrite it or demote it out of must-have scope.
+
 Publish `<!-- spec-final -->` with:
 
 1. `# Synthesized Implementation Spec`
@@ -38,6 +40,7 @@ Publish `<!-- spec-final -->` with:
 7. TDD plan mapping every must-have criterion to a test level
 8. Definition of done
 9. Conflict-resolution log and any residual risks
+10. Contradiction matrix and minimum-viable-fix summary
 
 ## Boundaries
 

--- a/.opencode/commands/ghar-tdd-reviewer.md
+++ b/.opencode/commands/ghar-tdd-reviewer.md
@@ -27,6 +27,9 @@ To publish an artifact, write the complete Markdown body to a temporary file. It
 
 Read the issue, codebase, test framework, and only the `spec-final` planning artifact. Verify its marker exists. Attack the spec from a testability perspective.
 
+Every must-have criterion must map to a runtime-observable test. Prefer behavior-level assertions over source inspection or private implementation probes whenever the behavior is observable through the public surface.
+Require at least one behavior-level test, one negative case, and one regression case for each must-have criterion where applicable. If the spec cannot support that, the spec is not ready.
+
 Publish `<!-- spec-tdd-review -->` with:
 
 1. `# TDD Spec Review`

--- a/Makefile.ghar
+++ b/Makefile.ghar
@@ -10,7 +10,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/tbrandenburg/ghar/main/Makefile.ghar | make -f - install SOURCE_REPO=owner/repo
 
 # GHAR version (bumped on each release)
-GHAR_VERSION = 0.3.0
+GHAR_VERSION = 0.4.0
 
 # Default source repository (can be overridden)
 SOURCE_REPO ?= tbrandenburg/ghar
@@ -32,6 +32,7 @@ GHAR_FILES = \
 	.opencode/commands/ghar-planner-risks.md:Risk_planner_command \
 	.opencode/commands/ghar-spec-synthesizer.md:Spec_synthesizer_command \
 	.opencode/commands/ghar-spec-redteam.md:Spec_redteam_command \
+	.opencode/commands/ghar-implementation-redteam.md:Implementation_redteam_command \
 	.opencode/commands/ghar-tdd-reviewer.md:TDD_reviewer_command \
 	.opencode/commands/ghar-spec-finalizer.md:Spec_finalizer_command \
 	.opencode/commands/ghar-test-agent.md:Test_agent_command \

--- a/Makefile.ghar
+++ b/Makefile.ghar
@@ -10,7 +10,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/tbrandenburg/ghar/main/Makefile.ghar | make -f - install SOURCE_REPO=owner/repo
 
 # GHAR version (bumped on each release)
-GHAR_VERSION = 0.2.0
+GHAR_VERSION = 0.3.0
 
 # Default source repository (can be overridden)
 SOURCE_REPO ?= tbrandenburg/ghar
@@ -31,6 +31,7 @@ GHAR_FILES = \
 	.opencode/commands/ghar-planner-architecture.md:Architecture_planner_command \
 	.opencode/commands/ghar-planner-risks.md:Risk_planner_command \
 	.opencode/commands/ghar-spec-synthesizer.md:Spec_synthesizer_command \
+	.opencode/commands/ghar-spec-redteam.md:Spec_redteam_command \
 	.opencode/commands/ghar-tdd-reviewer.md:TDD_reviewer_command \
 	.opencode/commands/ghar-spec-finalizer.md:Spec_finalizer_command \
 	.opencode/commands/ghar-test-agent.md:Test_agent_command \


### PR DESCRIPTION
Bumps GHAR to 0.4.0 on the existing release branch. This branch also includes the GHAR workflow and prompt hardening work already on the branch.