### PR TITLE
chore: bump ghar to 0.5.1

### DIFF
--- a/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
+++ b/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
@@ -284,8 +284,15 @@ jobs:
             fi
 
             if [ "$pending_runs" -eq 0 ] && [ "$status_state" != "pending" ]; then
+              terminal_statuses="$(printf '%s' "$status_json" | jq '[.statuses[]? | select(.state != "success")] | length')"
+
+              if [ "$terminal_statuses" -gt 0 ]; then
+                echo "Latest CI checks failed for ${SHA}" >&2
+                printf '%s' "$status_json" | jq -r '.statuses[]? | select(.state != "success") | "- \(.context): \(.state)\n  \(.target_url // "")"' >&2
+                exit 1
+              fi
+
               echo "Latest CI checks have settled for ${SHA}"
-              printf '%s' "$status_json" | jq -r '.statuses[]? | select(.state != "success") | "- \(.context): \(.state)\n  \(.target_url // "")"' >&2
               exit 0
             fi
 

--- a/.opencode/commands/ghar-fixer-integrator.md
+++ b/.opencode/commands/ghar-fixer-integrator.md
@@ -29,6 +29,18 @@ Require `spec-approved`, `implementation-redteam-findings`, `review-findings`, `
 
 Own the repair loop end-to-end: after every push, re-check the latest branch head and wait for the newest CI cycle to settle. If checks are still pending, keep waiting rather than handing off early. If checks fail, classify the failure, repair it, and verify again before publishing the summary.
 
+Maintain the loop with the todo tool for the whole job. The todo list must contain the live steps below and keep exactly one `in_progress` item at a time:
+
+1. Perform RCA on the latest CI failure evidence
+2. Plan the smallest root-cause fix
+3. Implement the plan
+4. Commit and push the fix
+5. Wait for CI to reach a terminal state
+6. Re-run RCA if any terminal check is red
+7. Finalize only after the latest head is green
+
+If CI is red, do not treat the job as complete. Re-enter RCA and repair until the latest head is fully green, including terminal external statuses that are visible on the PR or commit.
+
 Production code and documentation may be changed. A small test correction is allowed only when the classifier/review evidence proves the test is wrong; explain it explicitly. Never remove, skip, or weaken a valid test. Run narrow verification and the feasible full suite, commit integrated changes if any, and push only `HEAD:refs/heads/$BRANCH`. Do not consider the fix complete until the latest branch head has terminal CI evidence for the required repository-native checks.
 
 Before verification, bootstrap the tools needed for the checks you are about to run. Detect the repo’s test or validation expectations first, then install or enable only the missing tools required in this job’s context. Treat earlier sub-workflow environments as unrelated; a tool available to the test agent is not guaranteed to exist here. If a tool is missing and cannot be installed, record that limitation explicitly instead of replacing the check with a weaker one.
@@ -44,4 +56,4 @@ Publish `<!-- fixer-summary -->` with:
 
 ## Boundaries
 
-Do not change acceptance criteria, approved architecture, or scope; do not redesign, weaken evidence, or push elsewhere. Prefer surgical fixes.
+Do not change acceptance criteria, approved architecture, or scope; do not redesign, weaken evidence, or push elsewhere. Prefer surgical fixes. Do not hand off to `ghar-pr-finalizer` until the todo list is fully complete and the latest branch head is green.

--- a/.opencode/commands/ghar-pr-finalizer.md
+++ b/.opencode/commands/ghar-pr-finalizer.md
@@ -29,6 +29,8 @@ Require all artifacts: `spec-approved`, `tests-created`, `implementation-done`, 
 
 Treat any CI state older than the latest fixer push as stale. Do not finalize if the latest branch head has pending, failing, missing, or unobserved required repository-native checks. Require the post-fix CI gate to have observed the latest terminal CI state before considering the PR ready, and report any terminal external status failures separately.
 
+Refuse finalization if any terminal red status remains on the latest head, including external deployment or preview statuses shown by GitHub. The PR finalizer is a gate, not a waiver: if the head is not fully green, send the work back to the fixer loop and leave the PR unfinalized.
+
 Create exactly one pull request from `$BRANCH` to the repository default branch, or update the existing open/closed-unmerged pull request for that head. Never create a duplicate. The PR body must link `Closes #$ISSUE_NUMBER` and summarize scope, implementation, TDD commit ordering, tests/checks, review/red-team dispositions, frontier gaps, and unresolved risks. Do not enable auto-merge or merge the PR.
 
 Publish `<!-- pr-final -->` with:
@@ -43,4 +45,4 @@ Publish `<!-- pr-final -->` with:
 
 ## Boundaries
 
-Do not modify files/code/tests/spec, create commits, claim unverified CI success, hide risks, approve, or merge. The human reviewer is the first required interaction and owns the final decision.
+Do not modify files/code/tests/spec, create commits, claim unverified CI success, hide risks, approve, or merge. The human reviewer is the first required interaction and owns the final decision. Never publish `pr-final` while the latest head is red.

--- a/Makefile.ghar
+++ b/Makefile.ghar
@@ -10,7 +10,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/tbrandenburg/ghar/main/Makefile.ghar | make -f - install SOURCE_REPO=owner/repo
 
 # GHAR version (bumped on each release)
-GHAR_VERSION = 0.5.0
+GHAR_VERSION = 0.5.1
 
 # Default source repository (can be overridden)
 SOURCE_REPO ?= tbrandenburg/ghar


### PR DESCRIPTION
Patch version bump for GHAR.

Includes the CI gate/finalizer contract hardening from the prior turn.