### PR TITLE
feat(tdd-workflow): wire post-run-bash-command marker gates (v0.13.0)

### DIFF
--- a/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
+++ b/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
@@ -64,6 +64,9 @@ jobs:
       command: ghar-planner-requirements
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- plan-requirements -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -76,6 +79,9 @@ jobs:
       command: ghar-planner-architecture
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- plan-architecture -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -88,6 +94,9 @@ jobs:
       command: ghar-planner-risks
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- plan-risks -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -100,6 +109,9 @@ jobs:
       command: ghar-planner-research
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- plan-research -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -116,6 +128,9 @@ jobs:
       command: ghar-spec-synthesizer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- spec-final -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -128,6 +143,9 @@ jobs:
       command: ghar-spec-redteam
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- spec-redteam -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -140,6 +158,9 @@ jobs:
       command: ghar-tdd-reviewer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- spec-tdd-review -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -152,6 +173,9 @@ jobs:
       command: ghar-spec-finalizer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- spec-approved -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -164,6 +188,9 @@ jobs:
       command: ghar-test-agent
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- tests-created -->'
     permissions: {contents: write, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -176,6 +203,9 @@ jobs:
       command: ghar-implementer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- implementation-done -->'
     permissions: {contents: write, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -188,6 +218,9 @@ jobs:
       command: ghar-pr-seeder
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- pr-seeded -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -405,6 +438,9 @@ jobs:
       command: ghar-implementation-review
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- implementation-review-findings -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -417,6 +453,9 @@ jobs:
       command: ghar-maintainer-review
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- maintainer-review-findings -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -429,6 +468,9 @@ jobs:
       command: ghar-adversarial-review
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- adversarial-review-findings -->'
     permissions: {contents: write, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -441,6 +483,9 @@ jobs:
       command: ghar-residual-gap-review
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- residual-gap-findings -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -453,6 +498,9 @@ jobs:
       command: ghar-e2e-evidence
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- e2e-evidence -->'
     permissions:
       actions: read
       checks: read
@@ -475,6 +523,9 @@ jobs:
       command: ghar-review-fixer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- fixer-summary -->'
     permissions:
       contents: write
       issues: write
@@ -630,6 +681,9 @@ jobs:
       command: ghar-ci-fixer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- fixer-summary -->'
     permissions:
       actions: write
       checks: write
@@ -789,6 +843,9 @@ jobs:
       command: ghar-ci-fixer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- fixer-summary -->'
     permissions:
       actions: write
       checks: write
@@ -948,6 +1005,9 @@ jobs:
       command: ghar-ci-fixer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- fixer-summary -->'
     permissions:
       actions: write
       checks: write
@@ -1107,6 +1167,9 @@ jobs:
       command: ghar-pr-finalizer
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
+      post-run-bash-command: |
+        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
+          --jq '.body' | grep -q '<!-- pr-final -->'
     permissions:
       actions: read
       checks: read

--- a/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
+++ b/.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml
@@ -65,8 +65,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- plan-requirements -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- plan-requirements -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -80,8 +80,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- plan-architecture -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- plan-architecture -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -95,8 +95,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- plan-risks -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- plan-risks -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -110,8 +110,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- plan-research -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- plan-research -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -129,8 +129,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- spec-final -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- spec-final -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -144,8 +144,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- spec-redteam -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- spec-redteam -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -159,8 +159,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- spec-tdd-review -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- spec-tdd-review -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -174,8 +174,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- spec-approved -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- spec-approved -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -189,8 +189,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- tests-created -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- tests-created -->'
     permissions: {contents: write, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -204,8 +204,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- implementation-done -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- implementation-done -->'
     permissions: {contents: write, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -219,8 +219,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- pr-seeded -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- pr-seeded -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -439,8 +439,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- implementation-review-findings -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- implementation-review-findings -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -454,8 +454,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- maintainer-review-findings -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- maintainer-review-findings -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -469,8 +469,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- adversarial-review-findings -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- adversarial-review-findings -->'
     permissions: {contents: write, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -484,8 +484,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 45
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- residual-gap-findings -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- residual-gap-findings -->'
     permissions: {contents: read, issues: write, pull-requests: write}
     secrets: inherit
 
@@ -499,8 +499,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- e2e-evidence -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- e2e-evidence -->'
     permissions:
       actions: read
       checks: read
@@ -524,8 +524,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- fixer-summary -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- fixer-summary -->'
     permissions:
       contents: write
       issues: write
@@ -682,8 +682,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- fixer-summary -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- fixer-summary -->'
     permissions:
       actions: write
       checks: write
@@ -844,8 +844,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- fixer-summary -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- fixer-summary -->'
     permissions:
       actions: write
       checks: write
@@ -1006,8 +1006,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 60
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- fixer-summary -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- fixer-summary -->'
     permissions:
       actions: write
       checks: write
@@ -1168,8 +1168,8 @@ jobs:
       prompt: ${{ inputs.issue_number }}
       timeout-minutes: 30
       post-run-bash-command: |
-        gh api repos/${{ github.repository }}/issues/${{ inputs.issue_number }} \
-          --jq '.body' | grep -q '<!-- pr-final -->'
+        gh api --paginate "repos/${{ github.repository }}/issues/${{ inputs.issue_number }}/comments" \
+          --jq '.[].body' | grep -q '<!-- pr-final -->'
     permissions:
       actions: read
       checks: read

--- a/Makefile.ghar
+++ b/Makefile.ghar
@@ -10,7 +10,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/tbrandenburg/ghar/main/Makefile.ghar | make -f - install SOURCE_REPO=owner/repo
 
 # GHAR version (bumped on each release)
-GHAR_VERSION = 0.12.0
+GHAR_VERSION = 0.13.0
 
 # Default source repository (can be overridden)
 SOURCE_REPO ?= tbrandenburg/ghar


### PR DESCRIPTION
## Summary

Closes #22

Wires `post-run-bash-command` into every agent job in `ghar-multi-agent-tdd-issue-resolution.yml` that is contractually required to publish an HTML comment marker.

Each job now runs a deterministic bash gate after the agent completes. The gate calls `gh api` to fetch the issue body and asserts via `grep -q` that the required marker is present. A non-zero exit fails the job, preventing downstream jobs from proceeding with an incorrect view of the world.

## Jobs updated (21 total)

| Job | Required marker |
|-----|----------------|
| `ghar-planner-requirements` | `<!-- plan-requirements -->` |
| `ghar-planner-architecture` | `<!-- plan-architecture -->` |
| `ghar-planner-risks` | `<!-- plan-risks -->` |
| `ghar-planner-research` | `<!-- plan-research -->` |
| `ghar-spec-synthesizer` | `<!-- spec-final -->` |
| `ghar-spec-redteam` | `<!-- spec-redteam -->` |
| `ghar-tdd-reviewer` | `<!-- spec-tdd-review -->` |
| `ghar-spec-finalizer` | `<!-- spec-approved -->` |
| `ghar-test-agent` | `<!-- tests-created -->` |
| `ghar-implementer` | `<!-- implementation-done -->` |
| `ghar-pr-seeder` | `<!-- pr-seeded -->` |
| `ghar-implementation-review` | `<!-- implementation-review-findings -->` |
| `ghar-maintainer-review` | `<!-- maintainer-review-findings -->` |
| `ghar-adversarial-review` | `<!-- adversarial-review-findings -->` |
| `ghar-residual-gap-review` | `<!-- residual-gap-findings -->` |
| `ghar-e2e-evidence` | `<!-- e2e-evidence -->` |
| `ghar-review-fixer` | `<!-- fixer-summary -->` |
| `ghar-ci-fixer` (×3 rounds) | `<!-- fixer-summary -->` |
| `ghar-pr-finalizer` | `<!-- pr-final -->` |

## Changes

- `.github/workflows/ghar-multi-agent-tdd-issue-resolution.yml`: added `post-run-bash-command` to all 21 `core-opencode-run` job invocations
- `Makefile.ghar`: bumped `GHAR_VERSION` from `0.12.0` to `0.13.0`