### PR TITLE
Fix: gh pr review --approve gated on fragile artifact chain, PRs never get approved (#27)

### DIFF
--- a/.claude/PRPs/issues/completed/issue-27.md
+++ b/.claude/PRPs/issues/completed/issue-27.md
@@ -1,0 +1,25 @@
+# Issue 27 Archive
+
+Source: GitHub issue #27 investigation comment.
+
+## Issue
+
+`gh pr review --approve` was gated on a fragile artifact chain, so the finalizer could skip approval and still exit green.
+
+## Type
+
+BUG
+
+## Implementation Plan
+
+1. Recast Phase 1 as context reading, not the approval gate.
+2. Add a live issue-comment check immediately before `gh pr review --approve`.
+3. Update the phase checkpoint to reflect the hard approval gate.
+
+## Validation
+
+`git diff --check`
+
+## Notes
+
+The workspace did not contain `.claude/PRPs/issues/issue-27.md`, so this archive was created from the GitHub investigation comment.

--- a/.opencode/commands/ghar-pr-finalizer.md
+++ b/.opencode/commands/ghar-pr-finalizer.md
@@ -295,16 +295,22 @@ Do not enable auto-merge or merge the PR.
 
 Write the review body to a temporary file and post it:
 
+Only run the live comment check on the approval path.
+
+When CI is green and you are approving, run:
+
 ```bash
-COMMENT_BODIES=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" --jq '.[].body')
-echo "$COMMENT_BODIES" | grep -q '<!-- implementation-done -->' || { echo "FAIL: Missing <!-- implementation-done --> marker in live issue comments"; exit 1; }
-echo "$COMMENT_BODIES" | grep -q '<!-- tests-created -->' || { echo "FAIL: Missing <!-- tests-created --> marker in live issue comments"; exit 1; }
-echo "$COMMENT_BODIES" | grep -q '<!-- fixer-summary -->' || { echo "FAIL: Missing <!-- fixer-summary --> marker in live issue comments"; exit 1; }
+COMMENT_MARKERS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" --jq '.[].body | split("\n")[0]')
+echo "$COMMENT_MARKERS" | grep -Fxq '<!-- implementation-done -->' || { echo "FAIL: Missing <!-- implementation-done --> marker in live issue comments"; exit 1; }
+echo "$COMMENT_MARKERS" | grep -Fxq '<!-- tests-created -->' || { echo "FAIL: Missing <!-- tests-created --> marker in live issue comments"; exit 1; }
+echo "$COMMENT_MARKERS" | grep -Fxq '<!-- fixer-summary -->' || { echo "FAIL: Missing <!-- fixer-summary --> marker in live issue comments"; exit 1; }
 
-# When CI green and ready to approve
 gh pr review {NUMBER} --approve --body-file /tmp/pr-review-body.md
+```
 
-# When still draft / CI not green — comment only
+When still draft or CI is not green, run:
+
+```bash
 gh pr comment {NUMBER} --body-file /tmp/pr-review-body.md
 ```
 

--- a/.opencode/commands/ghar-pr-finalizer.md
+++ b/.opencode/commands/ghar-pr-finalizer.md
@@ -27,10 +27,10 @@ To publish an issue comment, write the complete Markdown body to a temporary fil
 
 ## Phase 1: VERIFY — Artifact Chain
 
-Require all required issue comments: `spec-approved`, `tests-created`, `implementation-done`, `implementation-review-findings`, `maintainer-review-findings`, `adversarial-review-findings`, `residual-gap-findings`, `pr-seeded`, `e2e-evidence`, and `fixer-summary`. If any are missing, stop and report which are absent.
+Read the required issue comments for context, but do not use this phase as the approval gate. The approval decision must be based on a live issue-comment check immediately before `gh pr review --approve`.
 
 **PHASE_1_CHECKPOINT:**
-- [ ] All 10 artifact comments present
+- [ ] Required issue comments read for context
 
 ---
 
@@ -296,6 +296,11 @@ Do not enable auto-merge or merge the PR.
 Write the review body to a temporary file and post it:
 
 ```bash
+COMMENT_BODIES=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/comments?per_page=100" --jq '.[].body')
+echo "$COMMENT_BODIES" | grep -q '<!-- implementation-done -->' || { echo "FAIL: Missing <!-- implementation-done --> marker in live issue comments"; exit 1; }
+echo "$COMMENT_BODIES" | grep -q '<!-- tests-created -->' || { echo "FAIL: Missing <!-- tests-created --> marker in live issue comments"; exit 1; }
+echo "$COMMENT_BODIES" | grep -q '<!-- fixer-summary -->' || { echo "FAIL: Missing <!-- fixer-summary --> marker in live issue comments"; exit 1; }
+
 # When CI green and ready to approve
 gh pr review {NUMBER} --approve --body-file /tmp/pr-review-body.md
 
@@ -392,6 +397,7 @@ fi
 **Why**: this keeps the PR body ownership in the finalizer, preserves multiline Markdown safely, and makes the body reflect the completed run rather than the bootstrap scaffold.
 
 **PHASE_7_CHECKPOINT:**
+- [ ] Live approval markers verified immediately before approval
 - [ ] PR body refreshed
 - [ ] PR created or updated
 - [ ] GitHub review posted (approve or comment)

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -32,5 +32,40 @@
       "gh run list --branch fix/issue-23-gh-pr-edit --limit 5 --json databaseId,workflowName,status,conclusion,headSha,displayTitle,createdAt -> []"
     ],
     "last_verified": "2026-06-20T08:47:01Z"
+  },
+  "ISSUE_27_ANALYSIS": {
+    "status": "done",
+    "evidence": [
+      "git diff --stat origin/main...HEAD -> .claude/PRPs/issues/completed/issue-27.md | 25 +++++++++++++++++++++++++, .opencode/commands/ghar-pr-finalizer.md | 20 ++++++++++++++++----",
+      "gh pr view 32 --json number,title,state,baseRefName,headRefName,mergeStateStatus,reviewDecision,body,url -> mergeStateStatus CLEAN, state OPEN",
+      "git show --stat 8ed32c3 -> Fix: gh pr review --approve gated on fragile artifact chain, PRs never get approved (#27)"
+    ],
+    "last_verified": "2026-06-20T12:51:49+02:00"
+  },
+  "ISSUE_27_PLAN": {
+    "status": "done",
+    "evidence": [
+      "git show --stat --patch --unified=40 8ed32c3 -> moved approval decision to a live comment check before gh pr review --approve",
+      "gh pr view 32 --json number,title,state,baseRefName,headRefName,mergeStateStatus,reviewDecision,body,url -> mergeStateStatus CLEAN, state OPEN"
+    ],
+    "last_verified": "2026-06-20T12:51:49+02:00"
+  },
+  "ISSUE_27_IMPLEMENTATION": {
+    "status": "done",
+    "evidence": [
+      "apply_patch -> added dev/state/task-ledger.json",
+      "jq empty dev/state/task-ledger.json && git diff --check -> no output"
+    ],
+    "last_verified": "2026-06-20T12:51:49+02:00"
+  },
+  "ISSUE_27_COMMIT_PUSH": {
+    "status": "in_progress",
+    "evidence": [],
+    "last_verified": "2026-06-20T12:51:49+02:00"
+  },
+  "ISSUE_27_CI_VERIFY": {
+    "status": "pending",
+    "evidence": [],
+    "last_verified": "2026-06-20T12:51:49+02:00"
   }
 }

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -40,7 +40,7 @@
       "gh pr view 32 --json number,title,state,baseRefName,headRefName,mergeStateStatus,reviewDecision,body,url -> mergeStateStatus CLEAN, state OPEN",
       "git show --stat 8ed32c3 -> Fix: gh pr review --approve gated on fragile artifact chain, PRs never get approved (#27)"
     ],
-    "last_verified": "2026-06-20T12:51:49+02:00"
+    "last_verified": "2026-06-20T12:53:39+02:00"
   },
   "ISSUE_27_PLAN": {
     "status": "done",
@@ -48,7 +48,7 @@
       "git show --stat --patch --unified=40 8ed32c3 -> moved approval decision to a live comment check before gh pr review --approve",
       "gh pr view 32 --json number,title,state,baseRefName,headRefName,mergeStateStatus,reviewDecision,body,url -> mergeStateStatus CLEAN, state OPEN"
     ],
-    "last_verified": "2026-06-20T12:51:49+02:00"
+    "last_verified": "2026-06-20T12:53:39+02:00"
   },
   "ISSUE_27_IMPLEMENTATION": {
     "status": "done",
@@ -59,13 +59,19 @@
     "last_verified": "2026-06-20T12:51:49+02:00"
   },
   "ISSUE_27_COMMIT_PUSH": {
-    "status": "in_progress",
-    "evidence": [],
+    "status": "done",
+    "evidence": [
+      "git commit -m \"chore: track issue 27 task ledger\" -> b2b80f0 chore: track issue 27 task ledger",
+      "git push -> fix/issue-27-pr-finalizer-live-comment-gate -> origin/fix/issue-27-pr-finalizer-live-comment-gate"
+    ],
     "last_verified": "2026-06-20T12:51:49+02:00"
   },
   "ISSUE_27_CI_VERIFY": {
-    "status": "pending",
-    "evidence": [],
+    "status": "blocked",
+    "evidence": [
+      "gh pr checks 32 -> no checks reported on the 'fix/issue-27-pr-finalizer-live-comment-gate' branch",
+      "gh run list --branch fix/issue-27-pr-finalizer-live-comment-gate --limit 10 --json databaseId,workflowName,status,conclusion,headSha,displayTitle,createdAt -> []"
+    ],
     "last_verified": "2026-06-20T12:51:49+02:00"
   }
 }


### PR DESCRIPTION
## Summary

This updates `ghar-pr-finalizer` so approval is no longer gated by the brittle artifact-chain check in Phase 1. The finalizer now verifies the required live issue comments immediately before `gh pr review --approve`.

## Changes

- Recast Phase 1 as context reading only
- Added a live `gh api .../comments` check for `implementation-done`, `tests-created`, and `fixer-summary`
- Updated the final checkpoint to reflect the hard approval gate

## Testing

- `git diff --check`

## Issue

Fixes #27